### PR TITLE
docs: Add a concept of diagrams using mermaid t

### DIFF
--- a/diagrams/01-overview.md
+++ b/diagrams/01-overview.md
@@ -1,0 +1,121 @@
+# 01 – HealthWeave Overview
+
+## What HealthWeave Is
+
+HealthWeave is an **AI-powered health data synthesis** application. Users upload medical documents (labs, imaging reports, clinical notes, PDFs, images). The system:
+
+1. Stores documents in object storage (S3).
+2. Extracts text from documents (PDF via pdfjs-dist; images placeholder until Textract).
+3. Sends document text + optional patient context to an LLM (AWS Bedrock, or Anthropic API / Ollama fallback).
+4. Parses the LLM’s markdown response into structured sections (summary, key findings, recommendations, etc.).
+5. Saves the report in DynamoDB and returns it to the client.
+6. Serves PDF download on demand (generated from the stored report).
+
+All actions are audit-logged (DynamoDB). There is no user authentication yet (userId defaults to `test-user`).
+
+---
+
+## Tech Stack
+
+```mermaid
+flowchart LR
+  subgraph Frontend["Frontend"]
+    Next["Next.js 16"]
+    React["React 19"]
+    Tailwind["Tailwind CSS"]
+    Next --> React
+    React --> Tailwind
+  end
+
+  subgraph Backend["Backend"]
+    Express["Express"]
+    TS["TypeScript"]
+    Express --> TS
+  end
+
+  subgraph AI["AI / LLM"]
+    Bedrock["AWS Bedrock"]
+    Anthropic["Anthropic API"]
+    Ollama["Ollama (local)"]
+  end
+
+  subgraph AWS["AWS (or LocalStack)"]
+    S3["S3"]
+    DDB["DynamoDB"]
+    Bedrock
+  end
+
+  Frontend -->|"REST (JSON)"| Backend
+  Backend --> S3
+  Backend --> DDB
+  Backend --> Bedrock
+  Backend -.->|"fallback"| Anthropic
+  Backend -.->|"fallback"| Ollama
+```
+
+- **Frontend**: Next.js 16, React 19, Tailwind. Single main page: upload (FileUpload) → results (AnalysisResults). Calls backend via `api.analyzeDocuments`, `api.downloadReportPDF`, etc.
+- **Backend**: Express, TypeScript. Handlers: `analyzeDocuments`, `getReport`, `getUserReports`, `downloadReportPDF`. Services: storage (S3 + text extraction), bedrock (LLM), report (DynamoDB + PDF), audit (DynamoDB).
+- **AI**: Primary = AWS Bedrock (configurable model). Fallback 1 = Anthropic API (if `ANTHROPIC_API_KEY` set). Fallback 2 = Ollama local (e.g. `mistral:latest`) when Bedrock unavailable (e.g. LocalStack).
+- **Storage**: S3 for document blobs; DynamoDB for reports and audit logs. LocalStack used in dev for AWS emulation.
+
+---
+
+## High-Level Architecture
+
+```mermaid
+flowchart TB
+  subgraph User["User"]
+    Browser["Browser"]
+  end
+
+  subgraph Frontend["Frontend (Next.js)"]
+    Page["page.tsx (Home)"]
+    FileUpload["FileUpload.tsx"]
+    AnalysisResults["AnalysisResults.tsx"]
+    API["lib/api.ts"]
+    Page --> FileUpload
+    Page --> AnalysisResults
+    FileUpload --> API
+    AnalysisResults --> API
+  end
+
+  subgraph Backend["Backend (Express)"]
+    Routes["Routes"]
+    Handler["handlers/analysis.ts"]
+    StorageSvc["services/storage.ts"]
+    BedrockSvc["services/bedrock.ts"]
+    ReportSvc["services/report.ts"]
+    AuditSvc["services/audit.ts"]
+    Routes --> Handler
+    Handler --> StorageSvc
+    Handler --> BedrockSvc
+    Handler --> ReportSvc
+    Handler --> AuditSvc
+  end
+
+  subgraph External["External"]
+    S3["S3"]
+    DynamoDB["DynamoDB"]
+    Bedrock["Bedrock / Anthropic / Ollama"]
+  end
+
+  Browser --> Frontend
+  API -->|"POST /api/analyze, GET /api/reports/..."| Backend
+  StorageSvc --> S3
+  ReportSvc --> DynamoDB
+  AuditSvc --> DynamoDB
+  BedrockSvc --> Bedrock
+```
+
+---
+
+## Main Flows (Summary)
+
+| Flow                  | Trigger                               | Path                                                                                    | Outcome                                                                             |
+| --------------------- | ------------------------------------- | --------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| **Analyze documents** | User submits files + optional context | POST /api/analyze → upload to S3 → extract text → Bedrock → parse → save report → audit | 201 + reportId, summary, keyFindings, recommendations, timing                       |
+| **View report**       | User opens result (or later: list)    | GET /api/reports/:reportId (body: userId)                                               | Full report JSON (id, summary, keyFindings, recommendations, fullReport, createdAt) |
+| **List reports**      | User (or UI) requests list            | GET /api/reports?limit=50 (body: userId)                                                | Array of reports for userId                                                         |
+| **Download PDF**      | User clicks download                  | GET /api/reports/:reportId/pdf?userId=...                                               | PDF binary (attachment)                                                             |
+
+All diagram files in this folder expand these flows in detail.

--- a/diagrams/02-user-flow.md
+++ b/diagrams/02-user-flow.md
@@ -1,0 +1,156 @@
+# 02 – User Flow (End-to-End)
+
+This diagram describes the **end-to-end user journey** from opening the app to viewing results and downloading the PDF. It is tailored for AI to understand the logical order of UI and API actions.
+
+---
+
+## User Journey Overview
+
+```mermaid
+flowchart LR
+  A["1. Land on app"] --> B["2. Enter optional context"]
+  B --> C["3. Add files (dropzone)"]
+  C --> D["4. Submit Analyze"]
+  D --> E["5. Wait (analysis runs)"]
+  E --> F["6. See results + Download PDF"]
+  F --> G["7. Optional: Analyze New Documents"]
+  G --> A
+```
+
+---
+
+## Detailed Sequence: Analyze Documents
+
+```mermaid
+sequenceDiagram
+  actor User
+  participant UI as Frontend (page.tsx)
+  participant FileUpload as FileUpload.tsx
+  participant API as lib/api
+  participant Backend as Express
+  participant Multer as multer
+  participant Handler as analysis handler
+  participant Storage as storage service
+  participant S3 as S3
+  participant Bedrock as bedrock service
+  participant LLM as Bedrock/Anthropic/Ollama
+  participant Report as report service
+  participant DDB as DynamoDB
+  participant Audit as audit service
+
+  User->>FileUpload: Fills patient context (optional)
+  User->>FileUpload: Drops/selects files (PDF, images, txt)
+  User->>FileUpload: Clicks "Analyze"
+  FileUpload->>UI: handleAnalyze(files, patientContext)
+  UI->>UI: setIsAnalyzing(true), setError(null)
+  UI->>API: analyzeDocuments(files, patientContext)
+
+  Note over API: FormData: documents[] + userId + patientContext
+  API->>Backend: POST /api/analyze (multipart/form-data)
+  Backend->>Multer: Parse multipart (max 25 files, 10MB each)
+  Multer-->>Handler: req.files, req.body.userId, req.body.patientContext
+
+  Handler->>Audit: logEvent(DOCUMENT_UPLOAD)
+  Audit->>DDB: PutItem (audit table)
+
+  loop For each file
+    Handler->>Storage: uploadFile(userId, fileName, buffer, mimeType)
+    Storage->>S3: PutObject (key: users/{userId}/documents/{fileId}/{fileName})
+    Storage-->>Handler: { key, url }
+    Handler->>Storage: extractTextContent(key, mimeType)
+    alt PDF
+      Storage->>S3: GetObject
+      Storage->>Storage: extractTextFromPDF (pdfjs-dist)
+    else text/json
+      Storage->>S3: GetObject
+      Storage->>Storage: buffer.toString('utf-8')
+    else image
+      Storage-->>Handler: placeholder text (Textract in prod)
+    end
+    Storage-->>Handler: extracted text
+    Handler->>Handler: documentContents.set(docId, content)
+  end
+
+  Handler->>Bedrock: analyzeHealthData(documents, documentContents, patientContext)
+  Bedrock->>Bedrock: buildSystemPrompt()
+  Bedrock->>Bedrock: buildUserMessage(docs, contents, context)
+  Bedrock->>LLM: invoke (system + user message)
+  LLM-->>Bedrock: raw markdown response
+  Bedrock-->>Handler: analysisText (full markdown)
+
+  Handler->>Handler: extractSection(analysisText, 'AI Summary', ...)
+  Handler->>Handler: extractList(analysisText, 'Key Findings', ...)
+  Handler->>Handler: extractSection(analysisText, 'Clinical Correlations', ...)
+  Handler->>Handler: extractList(analysisText, 'Recommendations', ...)
+  Handler->>Handler: extractSection(analysisText, 'Uncertainties and Limitations', ...)
+  Handler->>Handler: Build report object (summary, keyFindings, recommendations, fullReport)
+
+  Handler->>Report: saveReport(report)
+  Report->>DDB: PutItem (reports table)
+  Handler->>Audit: logEvent(ANALYSIS_COMPLETE, reportId)
+  Audit->>DDB: PutItem (audit table)
+
+  Handler-->>Backend: res.json({ success, reportId, summary, keyFindings, recommendations, documentCount, analysisDurationMs, ... })
+  Backend-->>API: 200 JSON
+  API-->>UI: result
+  UI->>UI: setAnalysisResult(result), setIsAnalyzing(false)
+  UI->>User: Show AnalysisResults (summary, findings, recommendations, Download PDF button)
+```
+
+---
+
+## Sequence: Download PDF
+
+```mermaid
+sequenceDiagram
+  actor User
+  participant UI as AnalysisResults.tsx
+  participant API as lib/api
+  participant Backend as Express
+  participant Handler as analysis handler
+  participant Report as report service
+  participant DDB as DynamoDB
+  participant Audit as audit service
+
+  User->>UI: Clicks "Download PDF"
+  UI->>API: downloadReportPDF(reportId)
+  API->>Backend: GET /api/reports/:reportId/pdf?userId=test-user
+  Backend->>Handler: getReport(reportId), then downloadReportPDF
+  Handler->>Report: getReport(reportId, userId)
+  Report->>DDB: Query/Scan by reportId + userId
+  DDB-->>Report: report item
+  Report-->>Handler: report (AnalysisResult)
+  Handler->>Report: generatePDF(report)
+  Report->>Report: PDFKit: header, summary, keyFindings, recommendations, fullReport (markdown), footer
+  Report-->>Handler: PDF Buffer
+  Handler->>Audit: logEvent(REPORT_DOWNLOAD)
+  Handler-->>Backend: res.send(pdfBuffer) (Content-Type: application/pdf, Content-Disposition: attachment)
+  Backend-->>API: PDF binary
+  API-->>UI: blob
+  UI->>UI: createObjectURL, <a download>.click()
+  User->>User: PDF file saved
+```
+
+---
+
+## UI State Flow
+
+```mermaid
+stateDiagram-v2
+  [*] --> Upload: App load
+  Upload --> Analyzing: Submit (files + context)
+  Analyzing --> Results: Success (reportId + data)
+  Analyzing --> Upload: Error (setError, user can retry)
+  Results --> Upload: "Analyze New Documents"
+  Results --> Downloading: Click Download PDF
+  Downloading --> Results: Blob received, trigger save
+```
+
+---
+
+## File and Request Constraints (for AI)
+
+- **Allowed file types**: `application/pdf`, `image/jpeg`, `image/png`, `text/plain`, `application/json`.
+- **Limits**: 25 files per request, 10MB per file (multer + frontend dropzone).
+- **Request body (POST /api/analyze)**: `multipart/form-data` with `documents` (files), `userId` (optional, default test-user), `patientContext` (optional string).
+- **Response (success)**: `success: true`, `reportId`, `summary`, `keyFindings`, `recommendations`, `documentCount`, `analysisDurationMs`, `analysisDurationFormatted`, `model` (e.g. mistral:latest when Ollama used).

--- a/diagrams/03-analysis-pipeline.md
+++ b/diagrams/03-analysis-pipeline.md
@@ -1,0 +1,131 @@
+# 03 – Analysis Pipeline (Detailed)
+
+This document describes the **analysis pipeline** from the moment the backend receives POST /api/analyze until the report is saved and the response is sent. It is the single place to understand ordering, error handling, and parsing logic.
+
+---
+
+## Pipeline Stages
+
+```mermaid
+flowchart TB
+  A["POST /api/analyze"] --> B["Validate: files present?"]
+  B -->|No| C["400 No files uploaded"]
+  B -->|Yes| D["Audit: DOCUMENT_UPLOAD"]
+  D --> E["For each file: upload S3 + extract text"]
+  E --> F["Bedrock: analyzeHealthData"]
+  F --> G["Parse LLM markdown"]
+  G --> H["Build AnalysisResult"]
+  H --> I["Report.saveReport"]
+  I --> J["Audit: ANALYSIS_COMPLETE"]
+  J --> K["200 + report payload"]
+```
+
+---
+
+## Stage 1: Upload and Extract (per file)
+
+```mermaid
+flowchart LR
+  subgraph File["Per file"]
+    F1["file buffer"] --> F2["storage.uploadFile"]
+    F2 --> F3["S3 PutObject\nkey: users/{userId}/documents/{fileId}/{fileName}"]
+    F3 --> F4["storage.extractTextContent(key, mimeType)"]
+    F4 --> F5{"mimeType?"}
+    F5 -->|PDF| F6["downloadFile → extractTextFromPDF (pdfjs-dist)"]
+    F5 -->|text/json| F7["downloadFile → buffer.toString('utf-8')"]
+    F5 -->|image| F8["placeholder string (Textract in prod)"]
+    F6 --> F9["documentContents.set(docId, text)"]
+    F7 --> F9
+    F8 --> F9
+  end
+```
+
+- **HealthDocument** created per file: `id` (uuid), `fileName`, `fileType`, `uploadedAt`, `s3Key`, `size`. No document ID is the S3 fileId; docId is generated in handler and used only to key `documentContents` and in the user message.
+- **Extract failure**: On exception, handler sets `documentContents.set(docId, '[Content extraction failed for {fileName}]')` and continues.
+
+---
+
+## Stage 2: AI Analysis (Bedrock Service)
+
+```mermaid
+flowchart TB
+  In["documents, documentContents Map, patientContext?"] --> BuildPrompt["buildSystemPrompt()"]
+  BuildPrompt --> BuildMsg["buildUserMessage(docs, contents, context)"]
+  BuildMsg --> Messages["messages = [{ role: 'user', content: [{ type: 'text', text: userMessage }] }]"]
+  Messages --> Invoke["invokeModel(systemPrompt, messages)"]
+  Invoke --> Ok{"Bedrock OK?"}
+  Ok -->|Yes| Return["return response text"]
+  Ok -->|No| Unavail["isBedrockUnavailable(error)?"]
+  Unavail -->|No| Throw["throw Failed to analyze health data"]
+  Unavail -->|Yes| Fallback["handleBedrockFallback"]
+  Fallback --> Anth["anthropicClient?"]
+  Anth -->|Yes| TryAnth["invokeAnthropicDirect"]
+  TryAnth --> AnthOk{"OK?"}
+  AnthOk -->|Yes| Return
+  AnthOk -->|No| Ollama
+  Anth -->|No| Ollama["invokeOllama (mistral:latest)"]
+  Ollama --> Return
+```
+
+- **System prompt**: Defines role (expert clinical analyst), citation requirements, reference-range rules (only flag abnormal when value outside stated range), depth/comprehensiveness, response structure (## AI Summary, ## Key Findings, ## Clinical Correlations, ## Recommendations, ## Uncertainties and Limitations, ## References).
+- **User message**: Patient context (if provided) + per-document block "--- Document N: filename ---", "Type: {Laboratory Results|Imaging Study|...}", "Content: {extracted text}". Document type is inferred from filename and content (e.g. lab, imaging, pathology, clinical note, genetic, cardiology).
+- **Fallback order**: Bedrock → Anthropic API (if ANTHROPIC_API_KEY) → Ollama (http://localhost:11434/api/chat, model mistral:latest, 10 min timeout).
+
+---
+
+## Stage 3: Parse LLM Response
+
+The LLM returns a single markdown string. The handler parses it into sections using helper functions. **Order of extraction matters** only for which header variant is tried first.
+
+```mermaid
+flowchart LR
+  Raw["analysisText\n(full markdown)"] --> S1["extractSection('AI Summary', 'Executive Summary', 'Summary')"]
+  Raw --> S2["extractList('Key Findings', 'Findings')"]
+  Raw --> S3["extractSection('Clinical Correlations', 'Correlations')"]
+  Raw --> S4["extractList('Recommendations', 'Recommendation')"]
+  Raw --> S5["extractSection('Uncertainties and Limitations', 'Uncertainties', 'Limitations')"]
+
+  S1 --> Summary["summary"]
+  S2 --> Findings["keyFindings[]"]
+  S3 --> Corr["clinicalCorrelations"]
+  S4 --> Recs["recommendations[]"]
+  S5 --> Uncert["uncertainties"]
+
+  Summary --> Enhance["enhancedSummary = summary + (correlations if present)"]
+  Findings --> FinalFindings["finalKeyFindings (or fallback: numbered/bulleted lines from full text)"]
+  Recs --> FinalRecs["finalRecommendations (or fallback: parse ## Recommendations section)"]
+```
+
+- **extractSection(text, ...headers)**: Tries `## Header`, `**Header**:`, `Header:` and returns content until next section or end.
+- **extractList(text, ...headers)**: Gets section first; then extracts items by `**Label:** content`, then `1. item`, then `-`/`*`/`•` items. Returns string array.
+- **Fallbacks**: If keyFindings length 0, use first 10 numbered or bulleted lines from full text. If recommendations length 0, find `## Recommendations` and parse numbered/bulleted lines.
+- **Default strings**: If no summary, use first 2000 chars of analysisText or "Analysis complete". If no findings, use `['Analysis completed. Review full report for details.']`. If no recommendations, use `['Review the full analysis report with your healthcare provider.']`.
+
+---
+
+## Stage 4: Build and Save Report
+
+```mermaid
+flowchart TB
+  P["Parsed sections + fullReport"] --> R["AnalysisResult"]
+  R --> Fields["id (uuid), userId, createdAt, summary: enhancedSummary, keyFindings, recommendations, citations: [], fullReport: analysisText"]
+  Fields --> Save["reportService.saveReport(report)"]
+  Save --> DDB["DynamoDB PutItem (reports table)"]
+  DDB --> Audit["auditService.logEvent(ANALYSIS_COMPLETE, report:reportId)"]
+  Audit --> Resp["Response JSON"]
+```
+
+- **AnalysisResult** type: `id`, `userId`, `createdAt`, `summary`, `keyFindings`, `recommendations`, `citations` (currently empty array), `fullReport`. Stored in DynamoDB with `createdAt` as number (epoch ms) for range key.
+- **Response** includes: `success`, `reportId`, `summary`, `keyFindings`, `recommendations`, `documentCount`, `analysisDurationMs`, `analysisDurationSeconds`, `analysisDurationFormatted`, `model`.
+
+---
+
+## Error Handling (Pipeline)
+
+- **No files**: 400, `{ success: false, error: 'No files uploaded' }`.
+- **Multer (e.g. file type/size)**: Error propagates to Express error middleware → 500.
+- **Storage/upload failure**: Throws → 500, audit not rolled back (DOCUMENT_UPLOAD already logged).
+- **Extract failure per file**: Logged; placeholder text stored; pipeline continues.
+- **Bedrock/fallback failure**: Throws → 500, `Failed to analyze health data`.
+- **Report save failure**: Throws → 500.
+- **Audit failure**: Logged but not thrown (audit must not break main flow).

--- a/diagrams/04-backend-services.md
+++ b/diagrams/04-backend-services.md
@@ -1,0 +1,140 @@
+# 04 – Backend Services
+
+This document describes the four main **backend services**, their responsibilities, and how the analysis handler uses them. All services are singletons (default export) and live under `backend/src/services/`.
+
+---
+
+## Service Overview
+
+```mermaid
+flowchart TB
+  subgraph Handler["handlers/analysis.ts"]
+    H["analyzeDocuments, getReport, getUserReports, downloadReportPDF"]
+  end
+
+  subgraph Storage["storage.ts"]
+    S1["uploadFile"]
+    S2["downloadFile"]
+    S3["extractTextContent"]
+    S4["getPresignedUploadUrl"]
+  end
+
+  subgraph Bedrock["bedrock.ts"]
+    B1["analyzeHealthData"]
+    B2["buildSystemPrompt (private)"]
+    B3["buildUserMessage (private)"]
+    B4["invokeModel / Anthropic / Ollama (private)"]
+  end
+
+  subgraph Report["report.ts"]
+    R1["saveReport"]
+    R2["getReport"]
+    R3["getUserReports"]
+    R4["generatePDF"]
+  end
+
+  subgraph Audit["audit.ts"]
+    A1["logEvent"]
+    A2["getUserAuditLogs"]
+    A3["getAuditLog"]
+  end
+
+  H --> S1
+  H --> S2
+  H --> S3
+  H --> B1
+  H --> R1
+  H --> R2
+  H --> R3
+  H --> R4
+  H --> A1
+```
+
+---
+
+## Storage Service
+
+**Purpose**: Store document blobs in S3 and extract text for analysis.
+
+| Method                                               | Input                       | Output               | Notes                                                                                                                                         |
+| ---------------------------------------------------- | --------------------------- | -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `uploadFile(userId, fileName, fileBuffer, mimeType)` | User id, name, buffer, type | `{ key, url }`       | Key: `users/{userId}/documents/{fileId}/{fileName}`. Creates bucket if LocalStack. Encryption: AES256 (dev) / aws:kms (prod).                 |
+| `downloadFile(key)`                                  | S3 key                      | `Buffer`             | GetObject, stream → buffer.                                                                                                                   |
+| `extractTextContent(key, mimeType)`                  | S3 key, MIME type           | `string`             | PDF: download + pdfjs-dist page-by-page text extraction + cleanup. Text/json: download + utf-8 decode. Image: placeholder (Textract in prod). |
+| `getPresignedUploadUrl(userId, fileName, mimeType)`  | User, name, type            | `{ uploadUrl, key }` | Presigned PutObject, 1h expiry. Not used by current analyze flow (upload is server-side via multer).                                          |
+
+**Config**: `config.s3.bucketName`, `config.s3.bucketRegion`, `config.aws.endpoint` (LocalStack), `config.env` (encryption).
+
+**Initialization**: If `config.aws.endpoint` set, calls `initializeBucket()` (HeadBucket / CreateBucket).
+
+---
+
+## Bedrock Service
+
+**Purpose**: Run LLM analysis on document contents + optional patient context. Single public method: `analyzeHealthData(documents, documentContents, patientContext)` → raw markdown string.
+
+**Internal flow** (see [05-bedrock-ai-flow.md](05-bedrock-ai-flow.md)):
+
+- `buildSystemPrompt()`: Returns long system prompt (citations, reference ranges, depth, response structure).
+- `buildUserMessage(documents, documentContents, patientContext)`: Builds user message with document type per file and full extracted text.
+- `invokeModel(systemPrompt, messages)`: Calls AWS Bedrock (model from config).
+- On Bedrock failure (e.g. LocalStack 501): `handleBedrockFallback` → Anthropic direct (if API key) → Ollama `mistral:latest`.
+
+**Config**: `config.aws.region`, `config.aws.endpoint`, `config.bedrock.modelId`, env `ANTHROPIC_API_KEY`.
+
+---
+
+## Report Service
+
+**Purpose**: Persist reports in DynamoDB and generate PDFs.
+
+| Method                          | Input                       | Output                 | Notes                                                                                                                                                             |
+| ------------------------------- | --------------------------- | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `saveReport(report)`            | AnalysisResult              | void                   | PutItem to reports table. `createdAt` stored as number (epoch ms).                                                                                                |
+| `getReport(reportId, userId)`   | Report id, user id          | AnalysisResult \| null | Query UserIdIndex + FilterExpression id; fallback Scan by id then filter userId (LocalStack GSI lag).                                                             |
+| `getUserReports(userId, limit)` | User id, limit (default 50) | AnalysisResult[]       | Query UserIdIndex, ScanIndexForward: false.                                                                                                                       |
+| `generatePDF(report)`           | AnalysisResult              | Promise\<Buffer\>      | PDFKit: title, report id, date, AI Summary, Key Findings, Recommendations, Detailed Analysis (fullReport as markdown via renderMarkdownToPDF), footer disclaimer. |
+
+**DynamoDB**: Table name from `config.dynamodb.reportsTable`. PK: `id`, SK: `createdAt`. GSI: UserIdIndex (userId PK, createdAt SK). LocalStack: table created on first use if missing.
+
+**PDF**: Uses `marked` for markdown → tokens; custom renderer for headings, paragraphs, lists, bold, citations. Strip/clean problematic chars for PDFKit.
+
+---
+
+## Audit Service
+
+**Purpose**: Append-only audit log for HIPAA/compliance. Does not throw on failure (logs only).
+
+| Method                                                            | Input                                                  | Output           | Notes                                                                                                           |
+| ----------------------------------------------------------------- | ------------------------------------------------------ | ---------------- | --------------------------------------------------------------------------------------------------------------- |
+| `logEvent(userId, action, resource, success, details?, request?)` | User, action, resource, success, optional details, req | void             | PutItem to audit table. Stores id, timestamp, userId, action, resource, ipAddress, userAgent, success, details. |
+| `getUserAuditLogs(userId, startDate?, endDate?, limit)`           | User, optional range, limit                            | AuditLog[]       | Query UserIdIndex.                                                                                              |
+| `getAuditLog(id, timestamp)`                                      | Id, timestamp                                          | AuditLog \| null | GetItem.                                                                                                        |
+
+**Actions used by handler**: `DOCUMENT_UPLOAD`, `ANALYSIS_COMPLETE`, `REPORT_VIEW`, `REPORTS_LIST`, `REPORT_DOWNLOAD`, `ANALYSIS_FAILED`.
+
+**Config**: `config.dynamodb.auditTable`. Table created on first use if LocalStack.
+
+---
+
+## Call Flow (Analyze Only)
+
+```mermaid
+sequenceDiagram
+  participant H as Handler
+  participant A as Audit
+  participant S as Storage
+  participant B as Bedrock
+  participant R as Report
+
+  H->>A: logEvent(DOCUMENT_UPLOAD)
+  loop each file
+    H->>S: uploadFile(...)
+    H->>S: extractTextContent(...)
+  end
+  H->>B: analyzeHealthData(docs, contents, context)
+  B-->>H: analysisText
+  H->>H: parse sections, build report
+  H->>R: saveReport(report)
+  H->>A: logEvent(ANALYSIS_COMPLETE)
+```

--- a/diagrams/05-bedrock-ai-flow.md
+++ b/diagrams/05-bedrock-ai-flow.md
@@ -1,0 +1,114 @@
+# 05 – Bedrock / AI Flow
+
+This document describes how the **AI analysis** works: system prompt, user message, model invocation, and fallback chain. It gives AI agents enough context to reason about prompt changes and model behavior.
+
+---
+
+## Entry Point
+
+**Single public method**: `bedrockService.analyzeHealthData(documents, documentContents, patientContext?)`
+
+- **Input**: `documents`: HealthDocument[] (id, fileName, fileType, s3Key, etc.); `documentContents`: Map\<docId, string\> (extracted text); `patientContext`: optional string.
+- **Output**: Raw markdown string (full analysis). Caller (handler) is responsible for parsing into sections.
+
+---
+
+## High-Level AI Flow
+
+```mermaid
+flowchart TB
+  A["analyzeHealthData(docs, contents, context)"] --> B["buildSystemPrompt()"]
+  B --> C["buildUserMessage(docs, contents, context)"]
+  C --> D["messages = [{ role: 'user', content: [{ type: 'text', text }] }]"]
+  D --> E["invokeModel(systemPrompt, messages)"]
+  E --> F{"Success?"}
+  F -->|Yes| G["return content[0].text"]
+  F -->|No| H["isBedrockUnavailable?"]
+  H -->|No| I["throw"]
+  H -->|Yes| J["handleBedrockFallback"]
+  J --> K["Anthropic direct?"]
+  K -->|Yes| L["invokeAnthropicDirect"]
+  L --> M{"OK?"}
+  M -->|Yes| G
+  M -->|No| N["invokeOllama"]
+  K -->|No| N
+  N --> G
+```
+
+---
+
+## System Prompt (Structure)
+
+The system prompt is a single long string. **Order of sections** (conceptual):
+
+1. **Role**: Expert clinical analyst, multi-specialty; synthesize health documents into actionable insights.
+2. **Citation requirements (mandatory)**: Every clinical claim must cite sources. Formats: ClinVar, OMIM, PMID, PharmGKB, CPIC, ACMG, NCCN, AHA, AASLD, etc. Acceptable vs unacceptable sources listed.
+3. **Reference range interpretation (mandatory)**: Only flag lab/imaging values as abnormal when they fall **outside** the stated reference range. Values within range must not be labeled elevated/low/abnormal. Rule applies to labeling only—does not reduce depth of analysis.
+4. **Depth and comprehensiveness (mandatory)**: Key Findings must have sub-bullets with specific values, ranges, citations; not just category headers. Recommendations must be full sentences with rationale and citations, not just "Immediate Actions" labels. Cover all document types.
+5. **Core responsibilities**: Clinical synthesis, pattern recognition, risk stratification, evidence-based recommendations, specialist-level analysis.
+6. **Clinical analysis framework**: Data integration, clinical interpretation, risk assessment, specialty-specific considerations (cardiology, hepatology, oncology, hematology, etc.).
+7. **Communication principles**: For specialists; clinical documentation standards.
+8. **Quality standards**: Accuracy (only cite from documents; reference-range rule; no hallucination), safety, clinical relevance.
+9. **Response structure**: Exact markdown sections required—## AI Summary, ## Key Findings (with example format), ## Clinical Correlations, ## Recommendations (with example), ## Uncertainties and Limitations, ## References. Key Findings and Recommendations explicitly required to be detailed.
+10. **Critical reminders**: Clinical decision support only; citations mandatory; check value vs reference range before labeling abnormal; output full depth.
+
+**Implementation**: `buildSystemPrompt()` in `backend/src/services/bedrock.ts` returns this string (template literal).
+
+---
+
+## User Message (Structure)
+
+- Opening line: "Please analyze the following patient health documents and provide a comprehensive clinical analysis:"
+- If `patientContext`: "**PATIENT CONTEXT:**" + context + "Please integrate this clinical context when interpreting findings."
+- "**MEDICAL DOCUMENTS FOR ANALYSIS:**" then for each document:
+  - "--- Document N: {fileName} ---"
+  - "Type: {Laboratory Results | Imaging Study | Pathology Report | Clinical Note | Genetic Test Report | Cardiology Study | Clinical Document}"
+  - "Content:\n{content from documentContents.get(doc.id)}"
+- **Document type** is inferred by `identifyDocumentType(fileName, content)` from filename and first 1000 chars (e.g. lab, cbc, imaging, ultrasound, ct, mri, pathology, genetic, ecg, echo).
+- Closing block: "**ANALYSIS REQUIREMENTS:**" with numbered instructions (summary, key findings with detail, correlations, recommendations with detail, uncertainties, important notes) and "Provide a COMPREHENSIVE, DETAILED analysis... Please begin your analysis:".
+
+---
+
+## Invoke: Bedrock
+
+- **Model**: `config.bedrock.modelId` (e.g. Claude model ID in prod, or mistral for LocalStack).
+- **Request body**: `max_tokens: 4096`, `messages`, and for Claude-style models `anthropic_version: 'bedrock-2023-05-31'`, `system: systemPrompt`. For non-Claude (e.g. Mistral), system prompt is prepended to the first user message.
+- **Response**: `response.body` JSON; extract `content[0].text`. On missing content, throw.
+
+---
+
+## Fallback: Anthropic Direct
+
+- **When**: Bedrock fails and `anthropicClient` is set (env `ANTHROPIC_API_KEY`).
+- **Model**: `claude-3-5-sonnet-20241022`, `max_tokens: 4096`, same system and messages (content flattened to string per message).
+- **Response**: `response.content` filter type `text`, join.
+
+---
+
+## Fallback: Ollama
+
+- **When**: Bedrock fails (and Anthropic if tried also failed). Used when LocalStack does not emulate Bedrock.
+- **Endpoint**: `POST http://localhost:11434/api/chat`.
+- **Body**: `model: 'mistral:latest'`, `messages: [{ role: 'system', content: systemPrompt }, { role: 'user', content: userMessage }]`, `stream: false`, `options: { temperature: 0.3, top_p: 0.9, num_ctx: 32768 }`.
+- **Timeout**: 10 minutes (AbortController). On timeout/connection error, throws with user-friendly message.
+- **Response**: `data.message?.content || data.response || data.text`.
+
+---
+
+## Bedrock “Unavailable” Detection
+
+`isBedrockUnavailable(error)` is true when **all** of:
+
+- `config.aws.endpoint` is set (LocalStack), and
+- One of: `error.name === 'InternalFailure'`, `error.$metadata?.httpStatusCode === 501`, `error.__type === 'InternalFailure'`, or message includes `'bedrock-runtime'` / `'not yet been emulated'`.
+
+Otherwise the error is rethrown (no fallback).
+
+---
+
+## Summary for AI Agents
+
+- **Prompt location**: `backend/src/services/bedrock.ts` — `buildSystemPrompt()`, `buildUserMessage()`.
+- **Reference-range rule**: Only flag values as abnormal when outside document’s stated range; still require full depth (sub-bullets, full recommendation sentences).
+- **Output**: One markdown string. Handler parses with `extractSection` / `extractList` for ## AI Summary, Key Findings, Clinical Correlations, Recommendations, Uncertainties and Limitations.
+- **Model chain**: Bedrock → Anthropic API → Ollama. No retries; first success returns.

--- a/diagrams/06-data-model.md
+++ b/diagrams/06-data-model.md
@@ -1,0 +1,163 @@
+# 06 – Data Model
+
+This document describes the **core types and storage shape** used across the application. It allows AI to reason about request/response shapes and persistence without reading type definitions line-by-line.
+
+---
+
+## Core Types (TypeScript)
+
+```mermaid
+classDiagram
+  class HealthDocument {
+    +string id
+    +string fileName
+    +string fileType
+    +Date uploadedAt
+    +string s3Key
+    +number size
+  }
+
+  class AnalysisResult {
+    +string id
+    +string userId
+    +Date createdAt
+    +string summary
+    +string[] keyFindings
+    +string[] recommendations
+    +Citation[] citations
+    +string fullReport
+  }
+
+  class Citation {
+    +string source
+    +string type
+    +string relevance
+  }
+
+  class AuditLog {
+    +string id
+    +Date timestamp
+    +string userId
+    +string action
+    +string resource
+    +string ipAddress
+    +string userAgent
+    +boolean success
+    +Record details
+  }
+
+  class AnalysisRequest {
+    +string userId
+    +HealthDocument[] documents
+    +string patientContext
+    +string[] requestedInsights
+  }
+
+  AnalysisResult --> Citation : citations
+  AnalysisRequest --> HealthDocument : documents
+```
+
+---
+
+## HealthDocument
+
+- **Where**: Created in handler per uploaded file; not stored as a standalone table. Stored implicitly via S3 key and in memory for the request.
+- **id**: UUID generated in handler; used to key `documentContents` and in user message (Document 1, 2, …).
+- **fileName**, **fileType**: Original name and MIME type from upload.
+- **uploadedAt**: New Date() at upload time.
+- **s3Key**: From storage.uploadFile: `users/{userId}/documents/{fileId}/{fileName}`.
+- **size**: File size in bytes.
+
+---
+
+## AnalysisResult
+
+- **Where**: Stored in DynamoDB (reports table); returned by GET /api/reports/:reportId and GET /api/reports; input to generatePDF.
+- **id**: UUID; primary key for report.
+- **userId**: Partition for user-scoped access; default `test-user` until auth.
+- **createdAt**: Stored as number (epoch ms) in DynamoDB for range key / sorting.
+- **summary**: Enhanced summary (may include clinical correlations); shown in UI and PDF.
+- **keyFindings**: Array of strings (each may contain markdown, e.g. **Label:** content).
+- **recommendations**: Array of strings.
+- **citations**: Array of Citation; currently always [] (TODO extract from analysis).
+- **fullReport**: Raw markdown from LLM; used for Detailed Analysis section in PDF and for re-parsing if needed.
+
+---
+
+## Citation (stub)
+
+- **source**, **type** ('document' | 'research' | 'clinical_guideline'), **relevance**. Not yet populated by parser.
+
+---
+
+## AuditLog
+
+- **Where**: DynamoDB audit table. Written by auditService.logEvent; read by getUserAuditLogs / getAuditLog.
+- **id**, **timestamp** (stored as number in DDB), **userId**, **action**, **resource**, **ipAddress**, **userAgent**, **success**, **details** (optional object).
+- **Actions** used: DOCUMENT_UPLOAD, ANALYSIS_COMPLETE, ANALYSIS_FAILED, REPORT_VIEW, REPORTS_LIST, REPORT_DOWNLOAD.
+
+---
+
+## Config (runtime)
+
+- **env**, **port**, **host**: Node env, server port, bind host.
+- **aws**: **region**, **endpoint** (optional, for LocalStack).
+- **bedrock**: **modelId** (e.g. Claude or mistral).
+- **s3**: **bucketName**, **bucketRegion**.
+- **dynamodb**: **reportsTable**, **auditTable**.
+- **cognito**: optional **userPoolId**, **clientId** (for future auth).
+- **security**: **jwtSecret**, **encryptionKey**.
+- **cors**: **origin**.
+- **logging**: **level**.
+
+---
+
+## DynamoDB Table Layouts
+
+**Reports table**
+
+- **PK**: id (string)
+- **SK**: createdAt (number, epoch ms)
+- **GSI**: UserIdIndex — PK: userId, SK: createdAt (most recent first for list).
+- **Items**: AnalysisResult with createdAt serialized as number.
+
+**Audit table**
+
+- **PK**: id (string)
+- **SK**: timestamp (number)
+- **GSI**: UserIdIndex — PK: userId, SK: timestamp.
+- **Items**: AuditLog with timestamp as number.
+
+---
+
+## Request/Response Shapes (analysis only)
+
+**POST /api/analyze (request)**
+
+- Content-Type: multipart/form-data.
+- Fields: `documents` (file[]), `userId` (optional), `patientContext` (optional).
+
+**POST /api/analyze (response 200)**
+
+- success: true
+- reportId: string
+- summary: string
+- keyFindings: string[]
+- recommendations: string[]
+- documentCount: number
+- analysisDurationMs: number
+- analysisDurationSeconds: number
+- analysisDurationFormatted: string
+- model: string (e.g. "mistral:latest")
+
+**GET /api/reports/:reportId (body: userId)**
+
+- Response: { success: true, report: AnalysisResult } or 404.
+
+**GET /api/reports (body: userId, query: limit)**
+
+- Response: { success: true, reports: AnalysisResult[] }.
+
+**GET /api/reports/:reportId/pdf (query: userId)**
+
+- Response: application/pdf binary, attachment filename healthweave-report-{reportId}.pdf.

--- a/diagrams/07-api-routes.md
+++ b/diagrams/07-api-routes.md
@@ -1,0 +1,115 @@
+# 07 – API Routes
+
+This document lists all **HTTP routes**, their handlers, and which services they use. It gives AI and humans a complete map of the backend API surface.
+
+---
+
+## Route Map
+
+```mermaid
+flowchart TB
+  subgraph Routes["Express routes"]
+    R1["POST /api/analyze"]
+    R2["GET /api/reports/:reportId"]
+    R3["GET /api/reports"]
+    R4["GET /api/reports/:reportId/pdf"]
+    R0["GET /health"]
+  end
+
+  subgraph Handlers["Handlers"]
+    H1["analyzeDocuments"]
+    H2["getReport"]
+    H3["getUserReports"]
+    H4["downloadReportPDF"]
+  end
+
+  R1 --> H1
+  R2 --> H2
+  R3 --> H3
+  R4 --> H4
+  R0 --> Health["JSON status"]
+```
+
+---
+
+## Route Details
+
+| Method | Path                       | Handler           | Auth                 | Description                                                                                                                                                                                             |
+| ------ | -------------------------- | ----------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| GET    | /health                    | (inline)          | No                   | Returns `{ status: 'healthy', timestamp, environment }`.                                                                                                                                                |
+| POST   | /api/analyze               | analyzeDocuments  | No (userId in body)  | Multipart upload: documents, userId, patientContext. Uploads to S3, extracts text, runs AI, parses response, saves report, audits. Returns reportId + summary + keyFindings + recommendations + timing. |
+| GET    | /api/reports/:reportId     | getReport         | No (userId in body)  | Body: userId. Returns full report JSON or 404. Logs REPORT_VIEW.                                                                                                                                        |
+| GET    | /api/reports               | getUserReports    | No (userId in body)  | Body/usage: userId. Query: limit (default 50). Returns list of reports for user (most recent first). Logs REPORTS_LIST.                                                                                 |
+| GET    | /api/reports/:reportId/pdf | downloadReportPDF | No (userId in query) | Query: userId. Fetches report, generates PDF, returns attachment. Logs REPORT_DOWNLOAD.                                                                                                                 |
+
+**Note**: All report routes currently use `userId = 'test-user'` when not supplied (TODO: JWT/auth).
+
+---
+
+## Middleware Order (Express)
+
+```mermaid
+flowchart LR
+  A["helmet"] --> B["cors"]
+  B --> C["express.json 10mb"]
+  C --> D["express.urlencoded 10mb"]
+  D --> E["request logging"]
+  E --> F["Routes"]
+  F --> G["404 handler"]
+  G --> H["Error handler"]
+```
+
+- **helmet**: Security headers.
+- **cors**: Origin check (development allows localhost/private IPs; production uses allowed list). Methods: GET, POST, PUT, DELETE, OPTIONS. Allowed headers: Content-Type, Authorization. Credentials: true.
+- **Body limits**: 10mb for JSON and urlencoded (needed for large context; actual file upload is multipart via multer in analyzeDocuments, 10MB per file, max 25 files).
+
+---
+
+## Service Usage by Route
+
+```mermaid
+flowchart TB
+  subgraph POST_analyze["POST /api/analyze"]
+    A1["audit.logEvent DOCUMENT_UPLOAD"]
+    A2["storage.uploadFile (per file)"]
+    A3["storage.extractTextContent (per file)"]
+    A4["bedrock.analyzeHealthData"]
+    A5["report.saveReport"]
+    A6["audit.logEvent ANALYSIS_COMPLETE"]
+  end
+
+  subgraph GET_report["GET /api/reports/:reportId"]
+    B1["report.getReport"]
+    B2["audit.logEvent REPORT_VIEW"]
+  end
+
+  subgraph GET_reports["GET /api/reports"]
+    C1["report.getUserReports"]
+    C2["audit.logEvent REPORTS_LIST"]
+  end
+
+  subgraph GET_pdf["GET /api/reports/:reportId/pdf"]
+    D1["report.getReport"]
+    D2["report.generatePDF"]
+    D3["audit.logEvent REPORT_DOWNLOAD"]
+  end
+```
+
+---
+
+## Error Responses
+
+- **400**: No files uploaded (POST /api/analyze).
+- **404**: Report not found (GET report or GET pdf).
+- **500**: Any thrown error in handler or service (e.g. S3, Bedrock, DynamoDB, PDF generation). Message in body only in development (config.env === 'development').
+- **CORS error**: Origin not allowed → response may be non-2xx; message from CORS callback.
+
+---
+
+## Quick Reference for AI
+
+- **Analyze**: POST /api/analyze, multipart with `documents`, `userId`, `patientContext`. Response includes reportId; use it for GET report and GET pdf.
+- **List reports**: GET /api/reports with body/param userId (e.g. test-user). Optional query limit.
+- **Single report**: GET /api/reports/:reportId, body userId.
+- **PDF**: GET /api/reports/:reportId/pdf?userId=... returns binary PDF; no JSON.
+- **Health**: GET /health for liveness/readiness.

--- a/diagrams/README.md
+++ b/diagrams/README.md
@@ -1,0 +1,32 @@
+# HealthWeave – Logical Flow Diagrams
+
+This folder contains **Mermaid diagrams** that describe the entire logical flow of the HealthWeave application. They are written so that **AI agents and humans** can quickly gain full context on what the system does, how data moves, and how components interact.
+
+## Purpose
+
+- **AI context**: Give LLMs and code-assist tools a complete picture of the app without reading every file.
+- **Onboarding**: New contributors (or future-you) can follow flows from user action to storage.
+- **Reference**: Single source of truth for request/response flow, service boundaries, and data shapes.
+
+## Diagram Index
+
+| File                                               | Contents                                                                             |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| [01-overview.md](01-overview.md)                   | What HealthWeave is, tech stack, high-level architecture, main flows.                |
+| [02-user-flow.md](02-user-flow.md)                 | End-to-end user journey: upload → analysis → results → PDF download.                 |
+| [03-analysis-pipeline.md](03-analysis-pipeline.md) | Detailed analysis pipeline: handler → storage → extract → AI → parse → report save.  |
+| [04-backend-services.md](04-backend-services.md)   | Backend services (Storage, Bedrock, Report, Audit), responsibilities, and call flow. |
+| [05-bedrock-ai-flow.md](05-bedrock-ai-flow.md)     | AI flow: system prompt, user message, Bedrock → Anthropic → Ollama fallback.         |
+| [06-data-model.md](06-data-model.md)               | Core types: HealthDocument, AnalysisResult, AuditLog, Config.                        |
+| [07-api-routes.md](07-api-routes.md)               | REST API routes, request/response shapes, and which handlers/services they use.      |
+
+## How to Use
+
+- **Render Mermaid**: Paste diagram code into [Mermaid Live](https://mermaid.live), VS Code (Mermaid extension), or GitHub (renders in .md).
+- **Navigate**: Start with `01-overview.md` for context, then follow the flow through `02` → `03` → `04` → `05` as needed. Use `06` and `07` for data and API reference.
+
+## Key Concepts (for AI)
+
+- **HealthWeave** = AI-powered health document synthesis. Users upload medical documents (PDF, images, text); the backend extracts text, sends it to an LLM (AWS Bedrock, or Anthropic/Ollama fallback), parses the markdown response into sections, stores the report in DynamoDB, and returns summary/findings/recommendations. Users can view results in the UI and download a PDF report.
+- **userId**: Currently default `test-user`; no auth yet. All report and audit data is keyed by userId.
+- **Single analysis** = one POST with N files → one report (id, summary, keyFindings, recommendations, fullReport). Report is persisted; PDF is generated on-demand from stored report.


### PR DESCRIPTION
Adds a diagrams/ folder with Mermaid docs that describe HealthWeave’s logical flow end-to-end. Intended for both humans and AI to get full context without reading the whole codebase.

## Included

- README – Index and how to use the diagrams
- 01-overview – What the app does, stack, high-level architecture
- 02-user-flow – User journey and sequences (analyze, PDF download)
- 03-analysis-pipeline – Upload → extract → AI → parse → save
- 04-backend-services – Storage, Bedrock, Report, Audit
- 05-bedrock-ai-flow – System/user prompts, Bedrock → Anthropic → Ollama
- 06-data-model – Core types and DynamoDB usage
- 07-api-routes – REST routes and which handlers/services they use
