### PR TITLE
feat: report history UI (#63)

### DIFF
--- a/docs/REPORT_HISTORY.md
+++ b/docs/REPORT_HISTORY.md
@@ -1,0 +1,91 @@
+# Report History UI
+
+## What is this?
+
+Every time you upload documents and run an analysis, HealthWeave saves the report to a database. The Report History feature lets you go back and view or download any of those past reports without having to re-upload your documents and re-run the analysis.
+
+---
+
+## How to use it
+
+### Viewing past reports
+
+1. On the main upload page, click the **Past Reports** button in the top-right corner of the header.
+2. You'll see a list of all your previous analyses, sorted by date. Each card shows:
+   - The date the analysis was run
+   - How many documents were analyzed and their file names
+   - A preview of the AI summary
+   - How many findings and recommendations were in the report
+   - Which AI model generated it
+3. Click **View** on any report to open the full analysis — same view as when you first ran it.
+4. Click **PDF** to download that report as a PDF directly from the history list.
+
+### Getting back
+
+- From the history list, click **New Analysis** to go back to the upload form.
+- From a report opened via history, you have two buttons at the top: **Analyze New Documents** (goes to upload form) and **Past Reports** (goes back to the history list).
+
+---
+
+## What was built
+
+### New component: `ReportHistory.tsx`
+
+This is the history list screen. When it loads, it calls the backend to fetch all reports for the current user (`GET /api/reports`), then displays them as cards. Key behaviours:
+
+- Shows a loading spinner while fetching
+- Shows a friendly empty state if there are no reports yet
+- Handles download directly from the list (same PDF download logic as the results screen)
+- Maps the stored report format into the format the results viewer expects, so opening a historical report looks identical to viewing a fresh one
+
+### Updated: `page.tsx`
+
+The main page now has three possible views instead of two:
+
+| View | What it shows |
+|------|--------------|
+| `upload` | The document upload form (default) |
+| `results` | The analysis results for the most recent or selected report |
+| `history` | The past reports list |
+
+A **Past Reports** button was added to the header (always visible) and also appears on the results view so you can navigate between them without losing context.
+
+### Updated: `AnalysisResults.tsx`
+
+Minor fixes applied alongside the new feature:
+- `window.URL` replaced with `globalThis.URL` (better cross-environment compatibility)
+- `parentNode.removeChild()` replaced with `element.remove()` (modern DOM API)
+- React list keys changed from array index to content-based keys (prevents subtle rendering bugs when list contents change)
+- Props marked as `readonly` (TypeScript best practice)
+
+---
+
+## How the data flows
+
+```
+User clicks "Past Reports"
+        ↓
+ReportHistory component loads
+        ↓
+GET /api/reports?userId=test-user  →  backend queries DynamoDB
+        ↓
+List of AnalysisResult objects returned
+        ↓
+Displayed as cards in the UI
+
+User clicks "View" on a card
+        ↓
+Report mapped to display format
+        ↓
+page.tsx switches to "results" view
+        ↓
+AnalysisResults component renders it (same as a fresh analysis)
+```
+
+---
+
+## Notes
+
+- There is no authentication yet — all reports are stored and retrieved under `test-user`. Once auth is added (issue #4), each user will only see their own reports.
+- The backend endpoint (`GET /api/reports`) already existed before this feature — this was purely a frontend change to expose that data in the UI.
+- Reports are stored indefinitely in DynamoDB. There is no delete or archive feature yet.

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -3,14 +3,18 @@
 import { useState } from 'react';
 import FileUpload from '@/components/FileUpload';
 import AnalysisResults from '@/components/AnalysisResults';
+import ReportHistory from '@/components/ReportHistory';
 import Logo from '@/components/Logo';
 import api from '@/lib/api';
 import { AnalyzeResponse } from '@/types';
+
+type View = 'upload' | 'results' | 'history';
 
 export default function Home() {
   const [isAnalyzing, setIsAnalyzing] = useState(false);
   const [analysisResult, setAnalysisResult] = useState<AnalyzeResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [view, setView] = useState<View>('upload');
 
   const handleAnalyze = async (files: File[], patientContext: string, localOnly?: boolean) => {
     setIsAnalyzing(true);
@@ -22,6 +26,7 @@ export default function Home() {
 
       if (result.success) {
         setAnalysisResult(result);
+        setView('results');
       } else {
         setError(result.error || 'Analysis failed');
       }
@@ -35,6 +40,12 @@ export default function Home() {
   const handleReset = () => {
     setAnalysisResult(null);
     setError(null);
+    setView('upload');
+  };
+
+  const handleViewHistoricalReport = (report: AnalyzeResponse) => {
+    setAnalysisResult(report);
+    setView('results');
   };
 
   return (
@@ -50,13 +61,29 @@ export default function Home() {
                 <p className="text-sm text-accent">Synthesizing Your Health Story</p>
               </div>
             </div>
+            <button
+              onClick={() => setView(view === 'history' ? 'upload' : 'history')}
+              className="inline-flex items-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary"
+            >
+              <svg className="mr-2 h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              Past Reports
+            </button>
           </div>
         </div>
       </header>
 
       {/* Main Content */}
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-        {!analysisResult ? (
+        {view === 'history' && (
+          <ReportHistory
+            onViewReport={handleViewHistoricalReport}
+            onBack={() => setView('upload')}
+          />
+        )}
+
+        {view === 'upload' && (
           <div className="max-w-3xl mx-auto">
             <div className="text-center mb-8">
               <h2 className="text-3xl font-bold text-gray-900 mb-4">
@@ -94,27 +121,28 @@ export default function Home() {
 
             <FileUpload onAnalyze={handleAnalyze} isAnalyzing={isAnalyzing} />
           </div>
-        ) : (
+        )}
+
+        {view === 'results' && analysisResult && (
           <div>
-            <div className="mb-6">
+            <div className="mb-6 flex items-center gap-3">
               <button
                 onClick={handleReset}
                 className="inline-flex items-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary"
               >
-                <svg
-                  className="mr-2 h-4 w-4"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M10 19l-7-7m0 0l7-7m-7 7h18"
-                  />
+                <svg className="mr-2 h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 19l-7-7m0 0l7-7m-7 7h18" />
                 </svg>
                 Analyze New Documents
+              </button>
+              <button
+                onClick={() => setView('history')}
+                className="inline-flex items-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary"
+              >
+                <svg className="mr-2 h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                Past Reports
               </button>
             </div>
             <AnalysisResults result={analysisResult} />

--- a/frontend/src/components/AnalysisResults.tsx
+++ b/frontend/src/components/AnalysisResults.tsx
@@ -5,7 +5,7 @@ import { AnalyzeResponse } from '@/types';
 import api from '@/lib/api';
 
 interface AnalysisResultsProps {
-  result: AnalyzeResponse;
+  readonly result: AnalyzeResponse;
 }
 
 /**
@@ -40,14 +40,14 @@ export default function AnalysisResults({ result }: AnalysisResultsProps) {
   const handleDownloadPDF = async () => {
     try {
       const blob = await api.downloadReportPDF(result.reportId);
-      const url = window.URL.createObjectURL(blob);
+      const url = globalThis.URL.createObjectURL(blob);
       const a = document.createElement('a');
       a.href = url;
       a.download = `healthweave-report-${result.reportId}.pdf`;
       document.body.appendChild(a);
       a.click();
-      window.URL.revokeObjectURL(url);
-      document.body.removeChild(a);
+      globalThis.URL.revokeObjectURL(url);
+      a.remove();
     } catch (error: any) {
       alert('Failed to download PDF: ' + error.message);
     }
@@ -136,10 +136,10 @@ export default function AnalysisResults({ result }: AnalysisResultsProps) {
         <div className="px-6 py-4">
           {result.keyFindings.length > 0 ? (
             <ul className="space-y-3">
-              {result.keyFindings.map((finding, index) => (
-                <li key={index} className="flex items-start">
+              {result.keyFindings.map((finding, i) => (
+                <li key={`finding-${finding.substring(0, 40)}`} className="flex items-start">
                   <span className="flex-shrink-0 h-6 w-6 flex items-center justify-center rounded-full bg-blue-100 text-primary font-semibold text-sm mr-3">
-                    {index + 1}
+                    {i + 1}
                   </span>
                   <div className="text-gray-700 flex-1">{renderMarkdown(finding)}</div>
                 </li>
@@ -159,8 +159,8 @@ export default function AnalysisResults({ result }: AnalysisResultsProps) {
         <div className="px-6 py-4">
           {result.recommendations.length > 0 ? (
             <ul className="space-y-3">
-              {result.recommendations.map((rec, index) => (
-                <li key={index} className="flex items-start">
+              {result.recommendations.map((rec) => (
+                <li key={`rec-${rec.substring(0, 40)}`} className="flex items-start">
                   <svg
                     className="flex-shrink-0 h-6 w-6 text-green-500 mr-3"
                     fill="none"
@@ -192,8 +192,8 @@ export default function AnalysisResults({ result }: AnalysisResultsProps) {
           </div>
           <div className="px-6 py-4">
             <ul className="space-y-3">
-              {(result.questionsForDoctor ?? []).map((q, index) => (
-                <li key={index} className="flex items-start">
+              {(result.questionsForDoctor ?? []).map((q) => (
+                <li key={`q-${q.substring(0, 40)}`} className="flex items-start">
                   <span className="flex-shrink-0 h-6 w-6 flex items-center justify-center rounded-full bg-amber-100 text-amber-800 font-semibold text-sm mr-3">
                     ?
                   </span>

--- a/frontend/src/components/ReportHistory.tsx
+++ b/frontend/src/components/ReportHistory.tsx
@@ -1,0 +1,171 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { AnalysisResult, AnalyzeResponse } from '@/types';
+import api from '@/lib/api';
+
+interface ReportHistoryProps {
+  readonly onViewReport: (report: AnalyzeResponse) => void;
+  readonly onBack: () => void;
+}
+
+function formatDate(value: Date | string): string {
+  const d = typeof value === 'string' ? new Date(value) : value;
+  return d.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
+}
+
+function toAnalyzeResponse(report: AnalysisResult): AnalyzeResponse {
+  return {
+    success: true,
+    reportId: report.id,
+    summary: report.summary,
+    keyFindings: report.keyFindings,
+    recommendations: report.recommendations,
+    questionsForDoctor: report.questionsForDoctor,
+    documentNames: report.documentNames,
+    modelUsed: report.modelUsed,
+  };
+}
+
+export default function ReportHistory({ onViewReport, onBack }: ReportHistoryProps) {
+  const [reports, setReports] = useState<AnalysisResult[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [downloading, setDownloading] = useState<string | null>(null);
+
+  useEffect(() => {
+    api.getUserReports()
+      .then((res) => setReports(res.reports ?? []))
+      .catch(() => setError('Failed to load report history'))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const handleDownload = async (reportId: string) => {
+    setDownloading(reportId);
+    try {
+      const blob = await api.downloadReportPDF(reportId);
+      const url = globalThis.URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `healthweave-report-${reportId}.pdf`;
+      document.body.appendChild(a);
+      a.click();
+      globalThis.URL.revokeObjectURL(url);
+      a.remove();
+    } catch (err: any) {
+      alert('Failed to download PDF: ' + err.message);
+    } finally {
+      setDownloading(null);
+    }
+  };
+
+  return (
+    <div className="max-w-4xl mx-auto">
+      <div className="mb-6 flex items-center justify-between">
+        <div>
+          <h2 className="text-2xl font-bold text-gray-900">Past Reports</h2>
+          <p className="text-sm text-gray-500 mt-1">Your previous health document analyses</p>
+        </div>
+        <button
+          onClick={onBack}
+          className="inline-flex items-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary"
+        >
+          <svg className="mr-2 h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+          </svg>
+          New Analysis
+        </button>
+      </div>
+
+      {loading && (
+        <div className="flex justify-center py-16">
+          <svg className="animate-spin h-8 w-8 text-primary" fill="none" viewBox="0 0 24 24">
+            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+          </svg>
+        </div>
+      )}
+
+      {error && (
+        <div className="p-4 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700">
+          {error}
+        </div>
+      )}
+
+      {!loading && !error && reports.length === 0 && (
+        <div className="text-center py-16 bg-white rounded-lg border border-gray-200">
+          <svg className="mx-auto h-12 w-12 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+          </svg>
+          <p className="mt-4 text-gray-500">No past reports yet. Upload documents to get started.</p>
+        </div>
+      )}
+
+      {!loading && reports.length > 0 && (
+        <div className="space-y-4">
+          {reports.map((report) => (
+            <div key={report.id} className="bg-white shadow-sm rounded-lg border border-gray-200 p-5">
+              <div className="flex items-start justify-between gap-4">
+                <div className="flex-1 min-w-0">
+                  {/* Date + doc count */}
+                  <div className="flex items-center gap-3 mb-2">
+                    <span className="text-sm font-medium text-gray-900">
+                      {formatDate(report.createdAt)}
+                    </span>
+                    {report.documentNames && report.documentNames.length > 0 && (
+                      <span className="text-xs text-gray-500 bg-gray-100 px-2 py-0.5 rounded-full">
+                        {report.documentNames.length} {report.documentNames.length === 1 ? 'document' : 'documents'}
+                      </span>
+                    )}
+                    {report.modelUsed && (
+                      <span className="text-xs text-gray-400">{report.modelUsed}</span>
+                    )}
+                  </div>
+
+                  {/* Document names */}
+                  {report.documentNames && report.documentNames.length > 0 && (
+                    <p className="text-xs text-gray-500 mb-2 truncate">
+                      {report.documentNames.join(', ')}
+                    </p>
+                  )}
+
+                  {/* Summary preview */}
+                  <p className="text-sm text-gray-600 line-clamp-2">
+                    {report.summary}
+                  </p>
+
+                  {/* Finding count chips */}
+                  <div className="flex gap-2 mt-3">
+                    <span className="text-xs bg-blue-50 text-blue-700 px-2 py-0.5 rounded-full">
+                      {report.keyFindings.length} findings
+                    </span>
+                    <span className="text-xs bg-green-50 text-green-700 px-2 py-0.5 rounded-full">
+                      {report.recommendations.length} recommendations
+                    </span>
+                  </div>
+                </div>
+
+                {/* Actions */}
+                <div className="flex flex-col gap-2 flex-shrink-0">
+                  <button
+                    onClick={() => onViewReport(toAnalyzeResponse(report))}
+                    className="inline-flex items-center px-3 py-1.5 text-sm font-medium rounded-md text-white bg-primary hover:bg-primary-dark transition-colors"
+                  >
+                    View
+                  </button>
+                  <button
+                    onClick={() => handleDownload(report.id)}
+                    disabled={downloading === report.id}
+                    className="inline-flex items-center px-3 py-1.5 text-sm font-medium rounded-md text-primary border border-primary hover:bg-blue-50 disabled:opacity-40 transition-colors"
+                  >
+                    {downloading === report.id ? 'Saving...' : 'PDF'}
+                  </button>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Add Past Reports view so users can browse, open, and download previous analyses. New ReportHistory component lists reports with date, document names, summary preview, and findings/recommendations counts. Past Reports button added to header and results view; clicking a report reopens it in the full AnalysisResults view.

Also fixes SonarQube issues in AnalysisResults: readonly props, globalThis over window, element.remove() over removeChild, content-based list keys.