### PR TITLE
Feature/site nav and housekeeping #95

### DIFF
--- a/backend/src/handlers/analysis.ts
+++ b/backend/src/handlers/analysis.ts
@@ -414,6 +414,42 @@ export const getUserReports = async (req: Request, res: Response) => {
 };
 
 /**
+ * Delete a report (user must own it)
+ */
+export const deleteReport = async (req: Request, res: Response) => {
+  const { reportId } = req.params;
+  const userId = (req.query.userId as string) || req.body?.userId || 'test-user'; // TODO: Get from JWT
+
+  logger.info('Deleting report', { reportId, userId });
+
+  try {
+    const report = await reportService.getReport(reportId, userId);
+    if (!report) {
+      return res.status(404).json({
+        success: false,
+        error: 'Report not found',
+      });
+    }
+
+    await reportService.deleteReport(reportId, userId);
+    await auditService.logEvent(userId, 'REPORT_DELETE', `report:${reportId}`, true, {}, req);
+
+    return res.status(204).send();
+  } catch (error: any) {
+    logger.error('Error deleting report', {
+      error: error?.message || String(error),
+      reportId,
+      userId,
+    });
+    return res.status(500).json({
+      success: false,
+      error: 'Failed to delete report',
+      message: error?.message || 'Unknown error',
+    });
+  }
+};
+
+/**
  * Download report as PDF
  */
 export const downloadReportPDF = async (req: Request, res: Response) => {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -9,6 +9,7 @@ import {
   getReport,
   getUserReports,
   downloadReportPDF,
+  deleteReport,
 } from './handlers/analysis';
 import { getPatientContext, savePatientContext } from './handlers/patientContext';
 
@@ -95,6 +96,7 @@ app.get('/health', (_req: Request, res: Response) => {
 app.post('/api/analyze', analyzeDocuments);
 app.get('/api/reports/:reportId', getReport);
 app.get('/api/reports', getUserReports);
+app.delete('/api/reports/:reportId', deleteReport);
 app.get('/api/reports/:reportId/pdf', downloadReportPDF);
 app.get('/api/patient-context', getPatientContext);
 app.post('/api/patient-context', savePatientContext);

--- a/backend/src/services/report.ts
+++ b/backend/src/services/report.ts
@@ -5,6 +5,7 @@ import {
 } from '@aws-sdk/client-dynamodb';
 import {
   DynamoDBDocumentClient,
+  DeleteCommand,
   PutCommand,
   QueryCommand,
   ScanCommand,
@@ -998,6 +999,35 @@ class ReportService {
     } catch (error) {
       logger.error('Error retrieving user reports', { error, userId });
       throw new Error('Failed to retrieve user reports');
+    }
+  }
+
+  /**
+   * Delete a report by ID for a user (ensures ownership via getReport)
+   */
+  async deleteReport(reportId: string, userId: string): Promise<void> {
+    await this.ensureTable();
+    logger.info('Deleting report', { reportId, userId });
+
+    const report = await this.getReport(reportId, userId);
+    if (!report) {
+      logger.warn('Report not found for delete', { reportId, userId });
+      return; // idempotent: no-op if not found
+    }
+
+    try {
+      const command = new DeleteCommand({
+        TableName: this.tableName,
+        Key: {
+          id: report.id,
+          createdAt: report.createdAt.getTime(),
+        },
+      });
+      await this.client.send(command);
+      logger.info('Report deleted successfully', { reportId, userId });
+    } catch (error: any) {
+      logger.error('Error deleting report', { error: error?.message, reportId, userId });
+      throw new Error('Failed to delete report');
     }
   }
 

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -1,0 +1,51 @@
+# HealthWeave Privacy
+
+*Last updated: 2025*
+
+## Overview
+
+HealthWeave is a demonstration application that processes health-related documents you upload to generate synthesized reports. This page describes how we handle data in the context of this application.
+
+## Data You Provide
+
+- **Documents**: Files you upload (e.g., PDFs, images, text) are sent to the application backend for analysis. They may be processed by an AI service (cloud or local, depending on configuration).
+- **Optional context**: You may provide brief patient context (e.g., reason for the upload) to improve the analysis. This is stored only as configured by the deployment.
+
+## How Data Is Used
+
+- Uploaded documents and any context are used solely to generate your analysis report.
+- Reports may be stored so you can view or download them later (e.g., in “Past Reports”).
+- We do not use your data for advertising or selling to third parties.
+
+## Storage and Retention
+
+- Report data may be stored in the application’s database (e.g., DynamoDB or equivalent) for the duration of the deployment.
+- You can delete individual reports from the Past Reports page when that feature is available.
+- Actual retention and backup policies depend on the environment where HealthWeave is run (e.g., your own infrastructure or a hosted demo).
+
+## Local and Cloud Modes
+
+- In **local-only** mode, documents may be processed entirely on your machine (e.g., via a local AI model). No health data need be sent to external services.
+- In **cloud** mode, documents may be sent to supported cloud AI services. Data handling then follows those providers’ policies as well as this application’s configuration.
+
+## Security
+
+- The application uses standard security practices (e.g., HTTPS, secure headers). Specific safeguards depend on the deployment environment.
+- You are responsible for using the application in a secure environment and not uploading documents through untrusted networks or devices if you are concerned about privacy.
+
+## Third Parties
+
+- If cloud AI or storage services are used, their respective privacy and data processing policies apply to the data they process or store.
+- We do not sell or share your personal health information with third parties for marketing.
+
+## Changes
+
+- We may update this privacy description from time to time. The “Last updated” date at the top will be revised when we do. Continued use of the application after changes constitutes acceptance of the updated description where applicable.
+
+## Contact
+
+- For questions or feedback about privacy, please open an issue or contact the project maintainers via the repository: [GitHub Issues](https://github.com/fleXRPL/healthweave/issues).
+
+---
+
+*This is a demonstration application. It is not a certified medical or health product. Always consider the sensitivity of your health data and use the application in accordance with your own privacy and security requirements.*

--- a/docs/TERMS.md
+++ b/docs/TERMS.md
@@ -1,0 +1,53 @@
+# HealthWeave Terms of Use
+
+*Last updated: 2025*
+
+## Acceptance
+
+By using HealthWeave, you agree to these terms. If you do not agree, do not use the application.
+
+## Nature of the Service
+
+- HealthWeave is a **demonstration application** that uses AI to analyze health-related documents you upload and to generate synthesized reports.
+- It is provided for informational and educational purposes only. It is **not** a medical device, clinical decision support system, or substitute for professional medical advice, diagnosis, or treatment.
+
+## No Medical Advice
+
+- **Always seek the advice of qualified healthcare providers** with any questions you have about a medical condition, treatment, or health decisions.
+- Do not rely on HealthWeave output for diagnosis, treatment, or any clinical decision. Reports are for your personal reference only.
+
+## Your Responsibilities
+
+- You are responsible for the documents you upload and for ensuring you have the right to use and process them.
+- You must use the application in compliance with applicable laws, including those governing health information (e.g., HIPAA or local equivalents) if you are subject to them.
+- You must not use HealthWeave for any illegal or unauthorized purpose.
+
+## Data and Privacy
+
+- Your use of the application may involve uploading sensitive health information. How that data is processed and stored is described in our [Privacy](PRIVACY.md) documentation.
+- By uploading documents, you acknowledge that they may be processed by the application and any configured AI or storage services as described in the documentation and deployment configuration.
+
+## Availability and Changes
+
+- The application may be modified, suspended, or discontinued at any time. We do not guarantee availability or specific features.
+- We may update these terms. Continued use after changes constitutes acceptance of the updated terms where applicable. The “Last updated” date reflects the latest revision.
+
+## Disclaimer of Warranties
+
+- HealthWeave is provided **“as is.”** We disclaim all warranties, express or implied, including merchantability and fitness for a particular purpose. We do not warrant that the application will be error-free, secure, or suitable for your specific use case.
+
+## Limitation of Liability
+
+- To the fullest extent permitted by law, the project and its contributors are not liable for any direct, indirect, incidental, special, or consequential damages arising from your use or inability to use HealthWeave, including any reliance on its output for health or medical decisions.
+
+## Open Source and Attribution
+
+- HealthWeave may be made available under an open source license. Your use may be subject to that license in addition to these terms. Attribution and license terms can be found in the project repository.
+
+## Contact
+
+- For questions about these terms or the application, please use [GitHub Issues](https://github.com/fleXRPL/healthweave/issues) or contact the project maintainers through the repository.
+
+---
+
+*This is a demonstration application. Use responsibly and always consult qualified healthcare providers for medical advice.*

--- a/docs/issues/ISSUE_local_llm_capability_tiers.md
+++ b/docs/issues/ISSUE_local_llm_capability_tiers.md
@@ -54,5 +54,5 @@ Add host-aware capability detection, tiered local-LLM profiles, resource guardra
 ## References
 
 - Local-only / privacy mode: #71
-- HealthWeave Production Readiness project: https://github.com/orgs/fleXRPL/projects/6
+- HealthWeave Production Readiness project: [https://github.com/orgs/fleXRPL/projects/6](https://github.com/orgs/fleXRPL/projects/6)
 - Discussion: host detection, resource guardrails, sidecar Ollama, capability tiers

--- a/frontend/src/app/about/page.tsx
+++ b/frontend/src/app/about/page.tsx
@@ -1,0 +1,54 @@
+import Header from '@/components/Header';
+import Footer from '@/components/Footer';
+
+export default function AboutPage() {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-gray-50 to-blue-50">
+      <Header />
+      <main className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        <h2 className="text-3xl font-bold text-gray-900 mb-6">About HealthWeave</h2>
+
+        <section className="mb-10">
+          <h3 className="text-xl font-semibold text-gray-900 mb-3">What is HealthWeave?</h3>
+          <p className="text-gray-600 mb-4">
+            HealthWeave is an AI-powered tool that helps you make sense of your health documents. 
+            Upload medical records, lab results, and clinical notes from multiple providers; 
+            HealthWeave analyzes them and produces a single, readable synthesis with key findings, 
+            recommendations, and questions you might want to ask your doctor.
+          </p>
+          <p className="text-gray-600">
+            It is designed for personal use to organize and understand your own health story—not 
+            as a replacement for your care team. Always rely on qualified healthcare providers 
+            for medical advice and decisions.
+          </p>
+        </section>
+
+        <section className="mb-10">
+          <h3 className="text-xl font-semibold text-gray-900 mb-3">How it works</h3>
+          <ol className="list-decimal list-inside space-y-4 text-gray-600">
+            <li>
+              <strong className="text-gray-900">Upload</strong> — Add one or more health documents 
+              (PDF, images, or text). You can include lab results, visit summaries, imaging reports, 
+              or other records you have.
+            </li>
+            <li>
+              <strong className="text-gray-900">Analyze</strong> — Our AI reads and analyzes your 
+              documents, identifying important results, trends, and connections across your records.
+            </li>
+            <li>
+              <strong className="text-gray-900">Report</strong> — You receive a synthesized report 
+              with a summary, key findings, recommendations, and suggested questions for your doctor. 
+              You can view it in the app or download it as a PDF and keep it in your Past Reports.
+            </li>
+          </ol>
+        </section>
+
+        <p className="text-sm text-amber-800 bg-amber-50 border border-amber-200 rounded-lg px-4 py-3">
+          For informational use only. Not a substitute for professional medical advice, diagnosis, 
+          or treatment. Always consult qualified healthcare providers for medical decisions.
+        </p>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -54,22 +54,39 @@ export default function Home() {
       <header className="bg-white shadow-sm">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
           <div className="flex items-center justify-between">
-            <div className="flex items-center space-x-4">
+            <button
+              type="button"
+              onClick={handleReset}
+              className="flex items-center space-x-4 text-left hover:opacity-90 transition-opacity focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary rounded-lg"
+              aria-label="Home"
+              title="Home"
+            >
               <Logo size="md" />
               <div>
                 <h1 className="text-2xl font-bold text-primary">HealthWeave</h1>
                 <p className="text-sm text-accent">Synthesizing Your Health Story</p>
               </div>
-            </div>
-            <button
-              onClick={() => setView(view === 'history' ? 'upload' : 'history')}
-              className="inline-flex items-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary"
-            >
-              <svg className="mr-2 h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
-              </svg>
-              Past Reports
             </button>
+            <div className="flex items-center gap-3">
+              <button
+                onClick={handleReset}
+                className="inline-flex items-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary"
+              >
+                <svg className="mr-2 h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+                </svg>
+                New Analysis
+              </button>
+              <button
+                onClick={() => setView(view === 'history' ? 'upload' : 'history')}
+                className="inline-flex items-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary"
+              >
+                <svg className="mr-2 h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                Past Reports
+              </button>
+            </div>
           </div>
         </div>
       </header>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -4,7 +4,8 @@ import { useState } from 'react';
 import FileUpload from '@/components/FileUpload';
 import AnalysisResults from '@/components/AnalysisResults';
 import ReportHistory from '@/components/ReportHistory';
-import Logo from '@/components/Logo';
+import Header from '@/components/Header';
+import Footer from '@/components/Footer';
 import api from '@/lib/api';
 import { AnalyzeResponse } from '@/types';
 
@@ -50,46 +51,10 @@ export default function Home() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-gray-50 to-blue-50">
-      {/* Header */}
-      <header className="bg-white shadow-sm">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
-          <div className="flex items-center justify-between">
-            <button
-              type="button"
-              onClick={handleReset}
-              className="flex items-center space-x-4 text-left hover:opacity-90 transition-opacity focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary rounded-lg"
-              aria-label="Home"
-              title="Home"
-            >
-              <Logo size="md" />
-              <div>
-                <h1 className="text-2xl font-bold text-primary">HealthWeave</h1>
-                <p className="text-sm text-accent">Synthesizing Your Health Story</p>
-              </div>
-            </button>
-            <div className="flex items-center gap-3">
-              <button
-                onClick={handleReset}
-                className="inline-flex items-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary"
-              >
-                <svg className="mr-2 h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 19l-7-7m0 0l7-7m-7 7h18" />
-                </svg>
-                New Analysis
-              </button>
-              <button
-                onClick={() => setView(view === 'history' ? 'upload' : 'history')}
-                className="inline-flex items-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary"
-              >
-                <svg className="mr-2 h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
-                </svg>
-                Past Reports
-              </button>
-            </div>
-          </div>
-        </div>
-      </header>
+      <Header
+        pastReportsAsToggle
+        onPastReportsClick={() => setView((v) => (v === 'history' ? 'upload' : 'history'))}
+      />
 
       {/* Main Content */}
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
@@ -111,6 +76,9 @@ export default function Home() {
                 generate comprehensive insights and actionable recommendations.
               </p>
             </div>
+            <p className="text-center text-sm text-amber-800 bg-amber-50 border border-amber-200 rounded-lg px-4 py-2 mb-6">
+              For informational use only. Not a substitute for professional medical advice.
+            </p>
 
             {error && (
               <div className="mb-6 p-4 bg-red-50 border border-red-200 rounded-lg">
@@ -142,6 +110,9 @@ export default function Home() {
 
         {view === 'results' && analysisResult && (
           <div>
+            <p className="text-sm text-amber-800 bg-amber-50 border border-amber-200 rounded-lg px-4 py-2 mb-4">
+              For informational use only. Not a substitute for professional medical advice.
+            </p>
             <div className="mb-6 flex items-center gap-3">
               <button
                 onClick={handleReset}
@@ -167,15 +138,7 @@ export default function Home() {
         )}
       </main>
 
-      {/* Footer */}
-      <footer className="bg-white border-t border-gray-200 mt-20">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-          <p className="text-center text-sm text-gray-500">
-            © 2025 HealthWeave. This is a demonstration application. Always consult with
-            qualified healthcare providers for medical advice.
-          </p>
-        </div>
-      </footer>
+      <Footer />
     </div>
   );
 }

--- a/frontend/src/app/privacy/page.tsx
+++ b/frontend/src/app/privacy/page.tsx
@@ -1,0 +1,91 @@
+import Header from '@/components/Header';
+import Footer from '@/components/Footer';
+
+export const metadata = {
+  title: 'Privacy - HealthWeave',
+  description: 'How HealthWeave handles your data and privacy.',
+};
+
+export default function PrivacyPage() {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-gray-50 to-blue-50">
+      <Header />
+      <main className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        <h2 className="text-3xl font-bold text-gray-900 mb-2">Privacy</h2>
+        <p className="text-sm text-gray-500 mb-8">Last updated: 2025</p>
+
+        <section className="prose prose-gray max-w-none space-y-6 text-gray-600">
+          <section>
+            <h3 className="text-xl font-semibold text-gray-900 mb-2">Overview</h3>
+            <p>
+              HealthWeave is a demonstration application that processes health-related documents you upload to generate synthesized reports. This page describes how we handle data in the context of this application.
+            </p>
+          </section>
+
+          <section>
+            <h3 className="text-xl font-semibold text-gray-900 mb-2">Data You Provide</h3>
+            <ul className="list-disc list-inside space-y-2">
+              <li><strong>Documents:</strong> Files you upload (e.g., PDFs, images, text) are sent to the application backend for analysis. They may be processed by an AI service (cloud or local, depending on configuration).</li>
+              <li><strong>Optional context:</strong> You may provide brief patient context to improve the analysis. This is stored only as configured by the deployment.</li>
+            </ul>
+          </section>
+
+          <section>
+            <h3 className="text-xl font-semibold text-gray-900 mb-2">How Data Is Used</h3>
+            <p>
+              Uploaded documents and any context are used solely to generate your analysis report. Reports may be stored so you can view or download them later (e.g., in Past Reports). We do not use your data for advertising or selling to third parties.
+            </p>
+          </section>
+
+          <section>
+            <h3 className="text-xl font-semibold text-gray-900 mb-2">Storage and Retention</h3>
+            <p>
+              Report data may be stored in the application’s database for the duration of the deployment. You can delete individual reports from the Past Reports page. Actual retention and backup policies depend on the environment where HealthWeave is run.
+            </p>
+          </section>
+
+          <section>
+            <h3 className="text-xl font-semibold text-gray-900 mb-2">Local and Cloud Modes</h3>
+            <p>
+              In <strong>local-only</strong> mode, documents may be processed entirely on your machine. No health data need be sent to external services. In <strong>cloud</strong> mode, documents may be sent to supported cloud AI services; data handling then follows those providers’ policies as well as this application’s configuration.
+            </p>
+          </section>
+
+          <section>
+            <h3 className="text-xl font-semibold text-gray-900 mb-2">Security</h3>
+            <p>
+              The application uses standard security practices (e.g., HTTPS, secure headers). You are responsible for using the application in a secure environment and not uploading documents through untrusted networks or devices if you are concerned about privacy.
+            </p>
+          </section>
+
+          <section>
+            <h3 className="text-xl font-semibold text-gray-900 mb-2">Third Parties</h3>
+            <p>
+              If cloud AI or storage services are used, their respective privacy and data processing policies apply. We do not sell or share your personal health information with third parties for marketing.
+            </p>
+          </section>
+
+          <section>
+            <h3 className="text-xl font-semibold text-gray-900 mb-2">Changes</h3>
+            <p>
+              We may update this privacy description from time to time. The “Last updated” date at the top will be revised when we do.
+            </p>
+          </section>
+
+          <section>
+            <h3 className="text-xl font-semibold text-gray-900 mb-2">Contact</h3>
+            <p>
+              For questions or feedback about privacy, please open an issue or contact the project maintainers via the repository:{' '}
+              <a href="https://github.com/fleXRPL/healthweave/issues" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">GitHub Issues</a>.
+            </p>
+          </section>
+        </section>
+
+        <p className="mt-8 text-sm text-gray-500 border-t border-gray-200 pt-6">
+          The canonical version of this document is maintained in the repository as <code className="bg-gray-100 px-1 rounded">docs/PRIVACY.md</code>.
+        </p>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/frontend/src/app/terms/page.tsx
+++ b/frontend/src/app/terms/page.tsx
@@ -1,0 +1,98 @@
+import Link from 'next/link';
+import Header from '@/components/Header';
+import Footer from '@/components/Footer';
+
+export const metadata = {
+  title: 'Terms of Use - HealthWeave',
+  description: 'Terms of use for HealthWeave.',
+};
+
+export default function TermsPage() {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-gray-50 to-blue-50">
+      <Header />
+      <main className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        <h2 className="text-3xl font-bold text-gray-900 mb-2">Terms of Use</h2>
+        <p className="text-sm text-gray-500 mb-8">Last updated: 2025</p>
+
+        <section className="prose prose-gray max-w-none space-y-6 text-gray-600">
+          <section>
+            <h3 className="text-xl font-semibold text-gray-900 mb-2">Acceptance</h3>
+            <p>
+              By using HealthWeave, you agree to these terms. If you do not agree, do not use the application.
+            </p>
+          </section>
+
+          <section>
+            <h3 className="text-xl font-semibold text-gray-900 mb-2">Nature of the Service</h3>
+            <p>
+              HealthWeave is a <strong>demonstration application</strong> that uses AI to analyze health-related documents you upload and to generate synthesized reports. It is provided for informational and educational purposes only. It is <strong>not</strong> a medical device, clinical decision support system, or substitute for professional medical advice, diagnosis, or treatment.
+            </p>
+          </section>
+
+          <section>
+            <h3 className="text-xl font-semibold text-gray-900 mb-2">No Medical Advice</h3>
+            <p>
+              <strong>Always seek the advice of qualified healthcare providers</strong> with any questions you have about a medical condition, treatment, or health decisions. Do not rely on HealthWeave output for diagnosis, treatment, or any clinical decision. Reports are for your personal reference only.
+            </p>
+          </section>
+
+          <section>
+            <h3 className="text-xl font-semibold text-gray-900 mb-2">Your Responsibilities</h3>
+            <p>
+              You are responsible for the documents you upload and for ensuring you have the right to use and process them. You must use the application in compliance with applicable laws, including those governing health information (e.g., HIPAA or local equivalents) if you are subject to them. You must not use HealthWeave for any illegal or unauthorized purpose.
+            </p>
+          </section>
+
+          <section>
+            <h3 className="text-xl font-semibold text-gray-900 mb-2">Data and Privacy</h3>
+            <p>
+              Your use of the application may involve uploading sensitive health information. How that data is processed and stored is described in our <Link href="/privacy" className="text-primary hover:underline">Privacy</Link> documentation. By uploading documents, you acknowledge that they may be processed by the application and any configured AI or storage services as described in the documentation and deployment configuration.
+            </p>
+          </section>
+
+          <section>
+            <h3 className="text-xl font-semibold text-gray-900 mb-2">Availability and Changes</h3>
+            <p>
+              The application may be modified, suspended, or discontinued at any time. We do not guarantee availability or specific features. We may update these terms; continued use after changes constitutes acceptance of the updated terms where applicable.
+            </p>
+          </section>
+
+          <section>
+            <h3 className="text-xl font-semibold text-gray-900 mb-2">Disclaimer of Warranties</h3>
+            <p>
+              HealthWeave is provided <strong>“as is.”</strong> We disclaim all warranties, express or implied, including merchantability and fitness for a particular purpose. We do not warrant that the application will be error-free, secure, or suitable for your specific use case.
+            </p>
+          </section>
+
+          <section>
+            <h3 className="text-xl font-semibold text-gray-900 mb-2">Limitation of Liability</h3>
+            <p>
+              To the fullest extent permitted by law, the project and its contributors are not liable for any direct, indirect, incidental, special, or consequential damages arising from your use or inability to use HealthWeave, including any reliance on its output for health or medical decisions.
+            </p>
+          </section>
+
+          <section>
+            <h3 className="text-xl font-semibold text-gray-900 mb-2">Open Source and Attribution</h3>
+            <p>
+              HealthWeave may be made available under an open source license. Your use may be subject to that license in addition to these terms. Attribution and license terms can be found in the project repository.
+            </p>
+          </section>
+
+          <section>
+            <h3 className="text-xl font-semibold text-gray-900 mb-2">Contact</h3>
+            <p>
+              For questions about these terms or the application, please use{' '}
+              <a href="https://github.com/fleXRPL/healthweave/issues" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">GitHub Issues</a> or contact the project maintainers through the repository.
+            </p>
+          </section>
+        </section>
+
+        <p className="mt-8 text-sm text-gray-500 border-t border-gray-200 pt-6">
+          The canonical version of this document is maintained in the repository as <code className="bg-gray-100 px-1 rounded">docs/TERMS.md</code>.
+        </p>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -1,0 +1,34 @@
+import Link from 'next/link';
+
+const GITHUB_ISSUES_URL = 'https://github.com/fleXRPL/healthweave/issues';
+
+export default function Footer() {
+  return (
+    <footer className="bg-white border-t border-gray-200 mt-20">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <p className="text-center text-sm text-amber-800 bg-amber-50 border border-amber-200 rounded-lg px-4 py-3 mb-4 max-w-2xl mx-auto">
+          <strong>For informational use only.</strong> Not a substitute for professional medical advice, diagnosis, or treatment. Always consult qualified healthcare providers for medical decisions.
+        </p>
+        <p className="text-center text-sm text-gray-500 mb-4">
+          © 2025 HealthWeave. This is a demonstration application.
+        </p>
+        <nav className="flex justify-center gap-6 text-sm" aria-label="Footer navigation">
+          <Link href="/privacy" className="text-primary hover:underline focus:outline-none focus:ring-2 focus:ring-primary rounded">
+            Privacy
+          </Link>
+          <Link href="/terms" className="text-primary hover:underline focus:outline-none focus:ring-2 focus:ring-primary rounded">
+            Terms
+          </Link>
+          <a
+            href={GITHUB_ISSUES_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary hover:underline focus:outline-none focus:ring-2 focus:ring-primary rounded"
+          >
+            Contact / Feedback
+          </a>
+        </nav>
+      </div>
+    </footer>
+  );
+}

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import Link from 'next/link';
+import Logo from '@/components/Logo';
+
+const navButtonClass =
+  'inline-flex items-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary';
+
+interface HeaderProps {
+  /** When true, Past Reports is a toggle button; when false, it links to home */
+  readonly pastReportsAsToggle?: boolean;
+  readonly onPastReportsClick?: () => void;
+}
+
+export default function Header({ pastReportsAsToggle, onPastReportsClick }: HeaderProps) {
+  return (
+    <header className="bg-white shadow-sm">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
+        <div className="flex items-center justify-between flex-wrap gap-4">
+          <Link
+            href="/"
+            className="flex items-center space-x-4 text-left hover:opacity-90 transition-opacity focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary rounded-lg"
+            aria-label="Home"
+            title="Home"
+          >
+            <Logo size="md" />
+            <div>
+              <h1 className="text-2xl font-bold text-primary">HealthWeave</h1>
+              <p className="text-sm text-accent">Synthesizing Your Health Story</p>
+            </div>
+          </Link>
+          <nav className="flex items-center gap-3 flex-wrap" aria-label="Main navigation">
+            <Link href="/" className={navButtonClass}>
+              <svg className="mr-2 h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+              </svg>
+              New Analysis
+            </Link>
+            {pastReportsAsToggle && typeof onPastReportsClick === 'function' ? (
+              <button type="button" onClick={onPastReportsClick} className={navButtonClass}>
+                <svg className="mr-2 h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                Past Reports
+              </button>
+            ) : (
+              <Link href="/" className={navButtonClass}>
+                <svg className="mr-2 h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                Past Reports
+              </Link>
+            )}
+            <Link href="/about" className={navButtonClass}>
+              About
+            </Link>
+          </nav>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/frontend/src/components/ReportHistory.tsx
+++ b/frontend/src/components/ReportHistory.tsx
@@ -32,12 +32,19 @@ export default function ReportHistory({ onViewReport, onBack }: ReportHistoryPro
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [downloading, setDownloading] = useState<string | null>(null);
+  const [deleting, setDeleting] = useState<string | null>(null);
 
-  useEffect(() => {
-    api.getUserReports()
+  const fetchReports = () => {
+    setLoading(true);
+    api
+      .getUserReports()
       .then((res) => setReports(res.reports ?? []))
       .catch(() => setError('Failed to load report history'))
       .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    fetchReports();
   }, []);
 
   const handleDownload = async (reportId: string) => {
@@ -56,6 +63,20 @@ export default function ReportHistory({ onViewReport, onBack }: ReportHistoryPro
       alert('Failed to download PDF: ' + err.message);
     } finally {
       setDownloading(null);
+    }
+  };
+
+  const handleDelete = async (reportId: string) => {
+    if (!confirm('Delete this report? This cannot be undone.')) return;
+    setDeleting(reportId);
+    setError(null);
+    try {
+      await api.deleteReport(reportId);
+      setReports((prev) => prev.filter((r) => r.id !== reportId));
+    } catch (err: any) {
+      setError(err.message || 'Failed to delete report');
+    } finally {
+      setDeleting(null);
     }
   };
 
@@ -159,6 +180,14 @@ export default function ReportHistory({ onViewReport, onBack }: ReportHistoryPro
                     className="inline-flex items-center px-3 py-1.5 text-sm font-medium rounded-md text-primary border border-primary hover:bg-blue-50 disabled:opacity-40 transition-colors"
                   >
                     {downloading === report.id ? 'Saving...' : 'PDF'}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleDelete(report.id)}
+                    disabled={deleting === report.id}
+                    className="inline-flex items-center px-3 py-1.5 text-sm font-medium rounded-md text-red-600 border border-red-300 hover:bg-red-50 disabled:opacity-40 transition-colors"
+                  >
+                    {deleting === report.id ? 'Deleting...' : 'Delete'}
                   </button>
                 </div>
               </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2,7 +2,7 @@ import axios, { AxiosInstance } from 'axios';
 import { AnalyzeResponse, ReportResponse, ReportsListResponse } from '@/types';
 
 class ApiClient {
-  private client: AxiosInstance;
+  private readonly client: AxiosInstance;
 
   constructor() {
     this.client = axios.create({
@@ -116,6 +116,23 @@ class ApiClient {
   }
 
   /**
+   * Delete a report
+   */
+  async deleteReport(reportId: string, userId?: string): Promise<void> {
+    try {
+      await this.client.delete(`/api/reports/${reportId}`, {
+        params: { userId: userId || 'test-user' },
+      });
+    } catch (error: any) {
+      throw new Error(
+        error.response?.data?.error ||
+          error.response?.data?.message ||
+          'Failed to delete report'
+      );
+    }
+  }
+
+  /**
    * Download report as PDF
    */
   async downloadReportPDF(reportId: string, userId?: string): Promise<Blob> {
@@ -179,7 +196,8 @@ class ApiClient {
       const response = await this.client.get('/health');
       return response.data;
     } catch (error: any) {
-      throw new Error('Backend is not reachable');
+      console.error('Health check failed', error);
+      throw new Error(error?.message || 'Backend is not reachable');
     }
   }
 }


### PR DESCRIPTION
Adds shared site navigation, delete report support, and standard site pages (About, Privacy, Terms, Contact) with a clearer medical disclaimer.

**Navigation**
- Logo + “HealthWeave” act as the **Home** button on all pages.
- **New Analysis** and **Past Reports** (toggle on home, link on other pages) in the header on every view.
- **About** in the header linking to a dedicated About page.

**About**
- **What is HealthWeave?** and **How it works** (Upload → Analyze → Report) on `/about`.

**Medical disclaimer**
- Stronger “for informational use only; not a substitute for professional medical advice” in the footer and near the upload and results sections.

**Privacy & Terms**
- **Privacy** and **Terms** in the footer linking to `/privacy` and `/terms`.
- Canonical text in `docs/PRIVACY.md` and `docs/TERMS.md`; app pages render equivalent content.

**Contact**
- **Contact / Feedback** in the footer links to [GitHub Issues](https://github.com/fleXRPL/healthweave/issues).

**Delete report**
- Backend: `DELETE /api/reports/:reportId` (ownership check, audit, 204 on success).
- Frontend: “Delete” on each report in Past Reports with confirmation and list refresh.

**Files**
- New: `Header`, `Footer`, `/about`, `/privacy`, `/terms`, `docs/PRIVACY.md`, `docs/TERMS.md`; backend `deleteReport` in report service and analysis handler.
- Updated: `page.tsx` (uses `Header`/`Footer`, disclaimers), `ReportHistory` (delete), `api.ts` (`deleteReport`), backend routes.

Closes #95.

---